### PR TITLE
Feat: ProfileResDto에서 User정보 함께 반환

### DIFF
--- a/src/main/java/team/themoment/imi/domain/profile/dto/ProfileResDto.java
+++ b/src/main/java/team/themoment/imi/domain/profile/dto/ProfileResDto.java
@@ -8,7 +8,12 @@ import java.util.List;
 @Setter
 @Builder
 public class ProfileResDto {
-    private Long userId;
+    //User
+    private String name;
+    private String email;
+    private int studentId; // 학번
+    //Profile
+    private Long id;
     private List<String> wanted;
     private String major;
     private String content;

--- a/src/main/java/team/themoment/imi/domain/profile/entity/Profile.java
+++ b/src/main/java/team/themoment/imi/domain/profile/entity/Profile.java
@@ -22,6 +22,6 @@ public class Profile {
     private String major;
     private String content;
 
-    @OneToOne(mappedBy = "profile")
+    @OneToOne(mappedBy = "profile",fetch = FetchType.EAGER)
     private User user;
 }

--- a/src/main/java/team/themoment/imi/global/mapper/ProfileMapper.java
+++ b/src/main/java/team/themoment/imi/global/mapper/ProfileMapper.java
@@ -12,7 +12,9 @@ import java.util.stream.Collectors;
 public class ProfileMapper {
     public ProfileResDto toProfileResDto(Profile profile){
         return ProfileResDto.builder()
-                .userId(profile.getUser().getId())
+                .name(profile.getUser().getName())
+                .email(profile.getUser().getEmail())
+                .studentId(profile.getUser().getStudentId())
                 .wanted(profile.getWanted())
                 .major(profile.getMajor())
                 .content(profile.getContent())


### PR DESCRIPTION
//문제
기존에는 ProfileResDto에서 userId를 반환 했지만, 명세서상 User 조회 API가 없어, 새 API 개발 또는 변경이 필요했습니다.

//한일
서비스상 Profile과 User는 따로 조회되는 일이 없으므로, ProfileResDto에 함께 담는것이 낫다고 판단되어, 그렇게 개발했습니다.

//TODO
두 엔티티가 분리된 취지는 Profile은 잦은 변경이 필요하지만, User는 그렇지 않은점 때문에 수정 API 개발을 구상하던 도중 분리될 필요를 느껴 Profile과 User를 분리했습니다. 하지만 ProfileResDto에 두개의 도메인이 담기면서 정체성이 애매해졌고, 향후 리팩토링이 필요했습니다.