### PR TITLE
update: AWS 마이그레이션을 위한 한경변수 주입 방식 변경

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,3 +1,5 @@
+spring.config.import=.env[.properties]
+
 spring.application.name=imi
 spring.datasource.url=jdbc:mysql://localhost:3306/imi
 spring.datasource.username=root

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,3 +1,5 @@
+spring.config.import=.env[.properties]
+
 spring.application.name=imi
 spring.datasource.url=jdbc:mysql://${MYSQL_ENDPOINT}/imi
 spring.datasource.username=${MYSQL_USER}


### PR DESCRIPTION
CloudType에서 AWS로 마이그레이션을 진행함에 따라 애플리케이션에 환경변수를 주입하는 방식을 변경하였습니다