### PR TITLE
이메일 인증 만료 관련 로직 수정

### DIFF
--- a/src/main/java/team/themoment/imi/domain/auth/exception/AuthCodeExpiredException.java
+++ b/src/main/java/team/themoment/imi/domain/auth/exception/AuthCodeExpiredException.java
@@ -1,0 +1,10 @@
+package team.themoment.imi.domain.auth.exception;
+
+import org.springframework.http.HttpStatus;
+import team.themoment.imi.global.exception.GlobalException;
+
+public class AuthCodeExpiredException extends GlobalException {
+    public AuthCodeExpiredException() {
+        super("인증 코드가 만료되었습니다.", HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/team/themoment/imi/domain/user/service/UserService.java
+++ b/src/main/java/team/themoment/imi/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import team.themoment.imi.domain.profile.entity.Profile;
 import team.themoment.imi.domain.user.entity.User;
 import team.themoment.imi.domain.user.exception.*;
 import team.themoment.imi.domain.user.repository.UserJpaRepository;
+import team.themoment.imi.global.email.entity.Authentication;
 import team.themoment.imi.global.email.repository.AuthenticationRedisRepository;
 import team.themoment.imi.global.utils.UserUtil;
 
@@ -28,12 +29,11 @@ public class UserService {
         if (userJpaRepository.existsByStudentId(studentId)) {
             throw new AlreadyMemberStudentIdException();
         }
-        authenticationRedisRepository.findById(email)
-                .ifPresent(authentication -> {
-                    if (!authentication.isVerified()) {
-                        throw new EmailNotVerifiedException();
-                    }
-                });
+        Authentication authentication = authenticationRedisRepository.findById(email)
+                .orElseThrow(EmailNotVerifiedException::new);
+        if (!authentication.isVerified()) {
+            throw new EmailNotVerifiedException();
+        }
         User user = User.builder()
                 .name(name)
                 .email(email)


### PR DESCRIPTION
인증 객체가 애초에 존재하지 않는다면 그냥 인증을 성공한것으로 간주하던 로직상의 논리적인 문제를 수정하였습니다