### PR TITLE
update: 명시적으로 Redis 객체 만료 시간단위 설정

### DIFF
--- a/src/main/java/team/themoment/imi/domain/auth/service/AuthService.java
+++ b/src/main/java/team/themoment/imi/domain/auth/service/AuthService.java
@@ -75,6 +75,7 @@ public class AuthService {
         AuthCode authCodeEntity = AuthCode.builder()
                 .email(email)
                 .authCode(authCode)
+                .expiration(AUTH_CODE_EXPIRATION_TIME)
                 .build();
         authCodeRedisRepository.save(authCodeEntity);
         authentication = Authentication.builder()

--- a/src/main/java/team/themoment/imi/global/email/entity/AuthCode.java
+++ b/src/main/java/team/themoment/imi/global/email/entity/AuthCode.java
@@ -7,6 +7,8 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
+import java.util.concurrent.TimeUnit;
+
 @RedisHash(value = "auth_code")
 @Getter
 @Builder
@@ -15,6 +17,6 @@ public class AuthCode {
     private String email;
     @Indexed
     private String authCode;
-    @TimeToLive
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private Long expiration;
 }

--- a/src/main/java/team/themoment/imi/global/email/entity/Authentication.java
+++ b/src/main/java/team/themoment/imi/global/email/entity/Authentication.java
@@ -6,6 +6,8 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
+import java.util.concurrent.TimeUnit;
+
 @RedisHash(value = "authentication")
 @Builder
 @Getter
@@ -14,6 +16,6 @@ public class Authentication {
     private String email;
     private int attempts;
     private boolean verified;
-    @TimeToLive
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private Long expiration;
 }

--- a/src/main/java/team/themoment/imi/global/security/jwt/entity/RefreshToken.java
+++ b/src/main/java/team/themoment/imi/global/security/jwt/entity/RefreshToken.java
@@ -7,6 +7,8 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
+import java.util.concurrent.TimeUnit;
+
 @RedisHash(value = "refresh_token")
 @Builder
 @Getter
@@ -15,6 +17,6 @@ public class RefreshToken {
     private String refreshToken;
     @Indexed
     private String userId;
-    @TimeToLive
+    @TimeToLive(unit = TimeUnit.SECONDS)
     private long expiration;
 }


### PR DESCRIPTION
코드에서 명시적으로 TTL의 시간단위를 명시하였습니다