### PR TITLE
feat: 인증코드 확인 API 횟수 제한 추가

### DIFF
--- a/src/main/java/team/themoment/imi/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/imi/domain/auth/controller/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
 
     @PostMapping("/verify-email")
     public ResponseEntity<Void> verifyEmail(@Valid @RequestBody VerifyEmailReqDto reqDto) {
-        authService.verifyAuthCode(reqDto.authCode());
+        authService.verifyAuthCode(reqDto.email(), reqDto.authCode());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/team/themoment/imi/domain/auth/data/request/VerifyEmailReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/auth/data/request/VerifyEmailReqDto.java
@@ -1,8 +1,11 @@
 package team.themoment.imi.domain.auth.data.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record VerifyEmailReqDto(
+        @NotBlank @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$") String email,
         @NotNull int authCode
 ) {
 }

--- a/src/main/java/team/themoment/imi/domain/auth/service/AuthService.java
+++ b/src/main/java/team/themoment/imi/domain/auth/service/AuthService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import team.themoment.imi.domain.auth.data.response.LoginResDto;
-import team.themoment.imi.domain.auth.exception.AuthCodeExpiredException;
 import team.themoment.imi.domain.auth.exception.InvalidAuthCodeException;
 import team.themoment.imi.domain.auth.exception.InvalidRefreshTokenException;
 import team.themoment.imi.domain.auth.exception.SignInFailedException;
@@ -64,11 +63,12 @@ public class AuthService {
         Authentication authentication = authenticationRedisRepository.findById(email)
                 .orElse(Authentication.builder()
                         .email(email)
-                        .attempts(0)
+                        .sendAttempt(0)
+                        .verificationAttempt(0)
                         .verified(false)
                         .expiration(AUTH_CODE_EXPIRATION_TIME)
                         .build());
-        if (authentication.getAttempts() >= MAX_AUTH_ATTEMPTS) {
+        if (authentication.getSendAttempt() >= MAX_AUTH_ATTEMPTS) {
             throw new ExcessiveAuthAttemptsException();
         }
         String authCode = generateRandomCode();
@@ -80,7 +80,8 @@ public class AuthService {
         authCodeRedisRepository.save(authCodeEntity);
         authentication = Authentication.builder()
                 .email(authentication.getEmail())
-                .attempts(authentication.getAttempts() + 1)
+                .sendAttempt(authentication.getSendAttempt() + 1)
+                .verificationAttempt(authentication.getVerificationAttempt())
                 .verified(false)
                 .expiration(AUTH_CODE_EXPIRATION_TIME)
                 .build();
@@ -88,17 +89,37 @@ public class AuthService {
         emailService.sendAuthenticationEmail(email, authCode);
     }
 
-    public void verifyAuthCode(int authCode) {
-        AuthCode savedAuthCode = authCodeRedisRepository.findByAuthCode(String.valueOf(authCode))
-                .orElseThrow(InvalidAuthCodeException::new);
-        String email = savedAuthCode.getEmail();
+    public void verifyAuthCode(String email, int authCode) {
         Authentication authentication = authenticationRedisRepository.findById(email)
-                .orElseThrow(AuthCodeExpiredException::new);
+                .orElse(Authentication.builder()
+                        .email(email)
+                        .sendAttempt(0)
+                        .verificationAttempt(0)
+                        .verified(false)
+                        .expiration(AUTH_CODE_EXPIRATION_TIME)
+                        .build());
+        if (authentication.getVerificationAttempt() >= MAX_AUTH_ATTEMPTS) {
+            throw new ExcessiveAuthAttemptsException();
+        }
+        AuthCode storedAuthCode = authCodeRedisRepository.findById(email)
+                .orElse(null);
+        if (storedAuthCode == null || !storedAuthCode.getAuthCode().equals(String.valueOf(authCode))) {
+            Authentication updatedAuthentication = Authentication.builder()
+                    .email(email)
+                    .sendAttempt(authentication.getSendAttempt())
+                    .verificationAttempt(authentication.getVerificationAttempt() + 1)
+                    .verified(false)
+                    .expiration(authentication.getExpiration())
+                    .build();
+            authenticationRedisRepository.save(updatedAuthentication);
+            throw new InvalidAuthCodeException();
+        }
         Authentication updatedAuthentication = Authentication.builder()
                 .email(email)
-                .attempts(authentication.getAttempts())
+                .sendAttempt(authentication.getSendAttempt())
+                .verificationAttempt(authentication.getVerificationAttempt())
                 .verified(true)
-                .expiration(authentication.getExpiration())
+                .expiration(AUTH_CODE_EXPIRATION_TIME)
                 .build();
         authenticationRedisRepository.save(updatedAuthentication);
         authCodeRedisRepository.deleteById(email);

--- a/src/main/java/team/themoment/imi/global/email/entity/Authentication.java
+++ b/src/main/java/team/themoment/imi/global/email/entity/Authentication.java
@@ -14,7 +14,8 @@ import java.util.concurrent.TimeUnit;
 public class Authentication {
     @Id
     private String email;
-    private int attempts;
+    private int sendAttempt;
+    private int verificationAttempt;
     private boolean verified;
     @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private Long expiration;

--- a/src/main/java/team/themoment/imi/global/email/repository/AuthCodeRedisRepository.java
+++ b/src/main/java/team/themoment/imi/global/email/repository/AuthCodeRedisRepository.java
@@ -8,5 +8,4 @@ import java.util.Optional;
 
 @Repository
 public interface AuthCodeRedisRepository extends CrudRepository<AuthCode, String> {
-    Optional<AuthCode> findByAuthCode(String authCode);
 }


### PR DESCRIPTION
``/auth/verify-email`` API를 단기간에 여러번 요청 시 5분간 제한 하도록 설정하였습니다