### PR TITLE
이메일 전송 및 인증 관련 코드 통일성 강화

### DIFF
--- a/src/main/java/team/themoment/imi/global/email/entity/AuthCode.java
+++ b/src/main/java/team/themoment/imi/global/email/entity/AuthCode.java
@@ -17,6 +17,6 @@ public class AuthCode {
     private String email;
     @Indexed
     private String authCode;
-    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    @TimeToLive(unit = TimeUnit.SECONDS)
     private Long expiration;
 }

--- a/src/main/java/team/themoment/imi/global/email/entity/Authentication.java
+++ b/src/main/java/team/themoment/imi/global/email/entity/Authentication.java
@@ -17,6 +17,6 @@ public class Authentication {
     private int sendAttempt;
     private int verificationAttempt;
     private boolean verified;
-    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    @TimeToLive(unit = TimeUnit.SECONDS)
     private Long expiration;
 }


### PR DESCRIPTION
Redis Entity의 TTL 설정이 어떤 것은 초 단위이고 어떤 곳은 밀리초 단위이던 것을 초 단위로 통일하였습니다
또한 직관적이지 않고 홀로 ``orElse()`` 메서드를 쓰던 부분도 분리하여 적용하였습니다