### PR TITLE
fix: RDB 칼럼의 실제 자료형과 JPA가 사용하려는 자료형의 불일치 문제 수정

### DIFF
--- a/src/main/java/team/themoment/imi/domain/club/entity/Club.java
+++ b/src/main/java/team/themoment/imi/domain/club/entity/Club.java
@@ -1,9 +1,6 @@
 package team.themoment.imi.domain.club.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 
 @Entity
@@ -16,5 +13,6 @@ public class Club {
     private String leader;
     private String mainContent;
     private String notionUrl;
+    @Column(columnDefinition = "VARCHAR(512)")
     private String iconUrl;
 }


### PR DESCRIPTION
``ddl-auto`` 프로퍼티가 활성화되어 있어 JPA가 애플리케이션 시동 시 RDB의 ``club`` 테이블에서 ``icon_url`` 칼럼을 ``VARCHAR(255)``으로 변경하려고 시도하던 문제를 ``VARCHAR(512)``으로 명시적으로 고정하여 해결하였습니다