### PR TITLE
update: 비밀번호 찾기 API 스펙 변경

### DIFF
--- a/src/main/java/team/themoment/imi/domain/user/controller/UserController.java
+++ b/src/main/java/team/themoment/imi/domain/user/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
 
     @PatchMapping("/password")
     public ResponseEntity<Void> updatePassword(@Valid @RequestBody UpdatePasswordReqDto dto) {
-        userService.updatePassword(dto.oldPassword(), dto.newPassword());
+        userService.updatePassword(dto.email(), dto.newPassword());
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/src/main/java/team/themoment/imi/domain/user/data/request/UpdatePasswordReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/UpdatePasswordReqDto.java
@@ -1,11 +1,15 @@
 package team.themoment.imi.domain.user.data.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record UpdatePasswordReqDto(
         @NotBlank(message = "기존 비밀번호를 입력해주세요.")
-        String oldPassword,
-        @NotBlank(message = "새 비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$",
+                message = "유효한 이메일 형식이 아닙니다.")
+        String email,
+        @NotBlank(message = "공백없이 새 비밀번호를 입력해주세요.")
         String newPassword
 ) {
 }

--- a/src/main/java/team/themoment/imi/domain/user/service/UserService.java
+++ b/src/main/java/team/themoment/imi/domain/user/service/UserService.java
@@ -71,11 +71,11 @@ public class UserService {
         );
     }
 
-    public void updatePassword(String oldPassword, String newPassword) {
+    public void updatePassword(String email, String newPassword) {
         User user = userUtil.getCurrentUser();
-
-        if (!passwordEncoder.matches(oldPassword, user.getPassword())) {
-            throw new InvalidPasswordException();
+        if (authenticationRedisRepository.findById(email)
+                .orElseThrow(EmailNotVerifiedException::new).isVerified()) {
+            throw new EmailNotVerifiedException();
         }
         user.setPassword(passwordEncoder.encode(newPassword));
         userJpaRepository.save(user);


### PR DESCRIPTION
비밀번호를 찾을 때 기존 비밀번호를 입력하여 새 비밀번호로 바꾸던 방식에서 이메일 인증을 이용하여 비밀번호를 변경하도록 수정하였습니다