### PR TITLE
update: 코드 형식 통일 및 엔드포인트 접근권한 조정

### DIFF
--- a/src/main/java/team/themoment/imi/domain/user/data/request/CheckEmailReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/CheckEmailReqDto.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record CheckEmailReqDto(
-
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "이메일 형식이 아닙니다.")
         String email

--- a/src/main/java/team/themoment/imi/domain/user/data/request/CreateUserReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/CreateUserReqDto.java
@@ -1,14 +1,13 @@
 package team.themoment.imi.domain.user.data.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 public record CreateUserReqDto(
         @NotBlank(message = "이름을 입력해주세요.")
         String name,
         @NotBlank(message = "이메일을 입력해주세요.")
+        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$"
+                , message = "이메일 형식이 올바르지 않습니다.")
         String email,
         @NotNull(message = "학번을 입력해주세요.")
         @Min(value = 1101, message = "학번을 다시 확인해주세요.")

--- a/src/main/java/team/themoment/imi/domain/user/data/request/UpdateUserReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/UpdateUserReqDto.java
@@ -1,11 +1,14 @@
 package team.themoment.imi.domain.user.data.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record UpdateUserReqDto(
         @NotBlank(message = "이름을 입력해주세요.")
         String name,
         @NotBlank(message = "이메일을 입력해주세요.")
+        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$",
+                message = "이메일 형식이 올바르지 않습니다.")
         String email,
         @NotBlank(message = "학번을 입력해주세요.")
         Integer studentId

--- a/src/main/java/team/themoment/imi/domain/user/service/UserService.java
+++ b/src/main/java/team/themoment/imi/domain/user/service/UserService.java
@@ -49,15 +49,7 @@ public class UserService {
         userJpaRepository.save(user);
     }
 
-    private boolean isEmailFormat(String email) {
-        return email.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$");
-    }
-
     public void updateUserInfo(String name, String email, int studentId) {
-        if (!isEmailFormat(email)) {
-            throw new EmailFormatException();
-        }
-
         User user = userUtil.getCurrentUser();
 
         userJpaRepository.save(
@@ -82,9 +74,6 @@ public class UserService {
     }
 
     public Boolean checkEmail(String email) {
-        if (!isEmailFormat(email)) {
-            throw new EmailFormatException();
-        }
         return userJpaRepository.existsByEmail(email);
     }
 }

--- a/src/main/java/team/themoment/imi/global/security/config/DomainAuthorizationConfig.java
+++ b/src/main/java/team/themoment/imi/global/security/config/DomainAuthorizationConfig.java
@@ -17,7 +17,7 @@ public class DomainAuthorizationConfig {
 
                 .requestMatchers("/user/join").permitAll()
                 .requestMatchers("/user/check-email").permitAll()
-                .requestMatchers("/user/password").authenticated()
+                .requestMatchers("/user/password").permitAll()
                 .requestMatchers("/user").authenticated()
 
                 .requestMatchers("/club").permitAll()


### PR DESCRIPTION
어떠한 API는 ``@Pattern`` 어노테이션을 사용하고 어떠한 API는 비즈니스 로직에서 정규식 메서드를 구현하여 검증하는 이원화된 검증 로직을 ``@Pattern`` 어노테이션을 이용하여 프레젠테이션 계층에서 검증하도록 통일 하였으며 ``PATCH /user/password`` 엔드포인트를 인증/인가 없이도 접근 가능하도록 조정하였습니다