### PR TITLE
update: 프레젠테이션 계층 검증 어노테이션 메세지 추가 및 JWT 필터 수정

### DIFF
--- a/src/main/java/team/themoment/imi/domain/auth/data/request/LoginReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/auth/data/request/LoginReqDto.java
@@ -6,7 +6,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record LoginReqDto(
-        @NotBlank @Email @Size(max = 16, min = 16) String email,
-        @NotBlank @Size(max = 16, min = 8) String password
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 아닙니다.")
+        @Size(max = 16, min = 16, message = "이메일은 16자리여야 합니다.")
+        String email,
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(max = 16, min = 8, message = "비밀번호는 8자 이상 16자 이하여야 합니다")
+        String password
 ) {
 }

--- a/src/main/java/team/themoment/imi/domain/auth/data/request/SendEmailReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/auth/data/request/SendEmailReqDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Pattern;
 
 public record SendEmailReqDto(
         @NotBlank(message = "이메일은 필수입니다.")
-        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$",
+        @Pattern(regexp = "^s\\d{5}@gsm\\.hs\\.kr$",
                 message = "유효한 이메일 형식이 아닙니다.")
         String email
 ) {

--- a/src/main/java/team/themoment/imi/domain/auth/data/request/SendEmailReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/auth/data/request/SendEmailReqDto.java
@@ -4,8 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record SendEmailReqDto(
-        @NotBlank
-        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$",
+                message = "유효한 이메일 형식이 아닙니다.")
         String email
 ) {
 }

--- a/src/main/java/team/themoment/imi/domain/auth/data/request/VerifyEmailReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/auth/data/request/VerifyEmailReqDto.java
@@ -5,7 +5,10 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public record VerifyEmailReqDto(
-        @NotBlank @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$") String email,
-        @NotNull int authCode
+        @NotBlank @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$"
+                , message = "유효한 이메일 형식이 아닙니다.")
+        String email,
+        @NotNull(message = "인증번호는 필수입니다.")
+        int authCode
 ) {
 }

--- a/src/main/java/team/themoment/imi/domain/auth/data/request/VerifyEmailReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/auth/data/request/VerifyEmailReqDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public record VerifyEmailReqDto(
-        @NotBlank @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$"
+        @NotBlank @Pattern(regexp = "^s\\d{5}@gsm\\.hs\\.kr$"
                 , message = "유효한 이메일 형식이 아닙니다.")
         String email,
         @NotNull(message = "인증번호는 필수입니다.")

--- a/src/main/java/team/themoment/imi/domain/profile/data/request/UpdateProfileReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/profile/data/request/UpdateProfileReqDto.java
@@ -7,8 +7,12 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record UpdateProfileReqDto(
-        @NotNull String major,
-        @NotNull @Size(max = 2400) String content,
-        @NotEmpty List<String> wanted
+        @NotNull(message = "희망전공은 필수입니다.")
+        String major,
+        @NotNull(message = "자기소개는 필수입니다.")
+        @Size(max = 2400, message = "자기소개는 최대 2400자까지 입력할 수 있습니다.")
+        String content,
+        @NotEmpty(message = "희망 동아리는 필수입니다.")
+        List<String> wanted
 ) {
 }

--- a/src/main/java/team/themoment/imi/domain/user/data/request/CreateUserReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/CreateUserReqDto.java
@@ -6,7 +6,7 @@ public record CreateUserReqDto(
         @NotBlank(message = "이름을 입력해주세요.")
         String name,
         @NotBlank(message = "이메일을 입력해주세요.")
-        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$"
+        @Pattern(regexp = "^s\\d{5}@gsm\\.hs\\.kr$"
                 , message = "이메일 형식이 올바르지 않습니다.")
         String email,
         @NotNull(message = "학번을 입력해주세요.")

--- a/src/main/java/team/themoment/imi/domain/user/data/request/UpdatePasswordReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/UpdatePasswordReqDto.java
@@ -6,8 +6,9 @@ import jakarta.validation.constraints.Pattern;
 
 public record UpdatePasswordReqDto(
         @NotBlank(message = "기존 비밀번호를 입력해주세요.")
-        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$",
-                message = "유효한 이메일 형식이 아닙니다.")
+        @Pattern(regexp = "^s\\d{5}@gsm\\.hs\\.kr$",
+                message = "유효한 이메일 형식이 아닙니다."
+        )
         String email,
         @NotBlank(message = "공백없이 새 비밀번호를 입력해주세요.")
         String newPassword

--- a/src/main/java/team/themoment/imi/domain/user/data/request/UpdateUserReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/UpdateUserReqDto.java
@@ -7,7 +7,7 @@ public record UpdateUserReqDto(
         @NotBlank(message = "이름을 입력해주세요.")
         String name,
         @NotBlank(message = "이메일을 입력해주세요.")
-        @Pattern(regexp = "^s\\d{5}@(gsm\\.hs\\.kr|gsmhs\\.kr)$",
+        @Pattern(regexp = "^s\\d{5}@gsm\\.hs\\.kr$",
                 message = "이메일 형식이 올바르지 않습니다.")
         String email,
         @NotBlank(message = "학번을 입력해주세요.")

--- a/src/main/java/team/themoment/imi/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/team/themoment/imi/global/security/filter/JwtAuthorizationFilter.java
@@ -34,6 +34,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 || request.getRequestURI().equals("/profile/list")
                 || request.getRequestURI().equals("/user/join")
                 || request.getRequestURI().equals("/user/check-email")
+                || request.getRequestURI().equals("/user/password")
                 || request.getRequestURI().startsWith("/club")) {
             filterChain.doFilter(request, response);
             return;


### PR DESCRIPTION
Jakarta 검증 어노테이션에서 검증 실패 시 메세지를 전체적으로 전부 추가하였으며 JWT 필터에서 ``/user/password`` 경로에 대해 필터 인가를 통과하도록 수정하였습니다