### PR TITLE
update: 에러 메세지 수정 및 비밀번호 재설정 시 사용자 정보 조회 방식 변경

### DIFF
--- a/src/main/java/team/themoment/imi/domain/user/data/request/UpdatePasswordReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/UpdatePasswordReqDto.java
@@ -1,11 +1,10 @@
 package team.themoment.imi.domain.user.data.request;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record UpdatePasswordReqDto(
-        @NotBlank(message = "기존 비밀번호를 입력해주세요.")
+        @NotBlank(message = "이메일을 입력해주세요.")
         @Pattern(regexp = "^s\\d{5}@gsm\\.hs\\.kr$",
                 message = "유효한 이메일 형식이 아닙니다."
         )

--- a/src/main/java/team/themoment/imi/domain/user/service/UserService.java
+++ b/src/main/java/team/themoment/imi/domain/user/service/UserService.java
@@ -64,7 +64,8 @@ public class UserService {
     }
 
     public void updatePassword(String email, String newPassword) {
-        User user = userUtil.getCurrentUser();
+        User user = userJpaRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
         if (authenticationRedisRepository.findById(email)
                 .orElseThrow(EmailNotVerifiedException::new).isVerified()) {
             throw new EmailNotVerifiedException();


### PR DESCRIPTION
비밀번호 재설정 API에서 ``email`` 필드가 비어있을 때 ``기존 비밀번호를 입력해주세요.`` 에러 메세지를 반환하던 것을 올바르게 수정하였고 비밀번호 재설정 비즈니스 로직에서 ``UserUtil``을 통하여 현재 사용자 정보를 가져오던 것을 JPA를 통해 직접 조회하도록 수정하였습니다