### PR TITLE
fix: if문 조건절 논리적 오류 해결

### DIFF
--- a/src/main/java/team/themoment/imi/domain/user/service/UserService.java
+++ b/src/main/java/team/themoment/imi/domain/user/service/UserService.java
@@ -66,7 +66,7 @@ public class UserService {
     public void updatePassword(String email, String newPassword) {
         User user = userJpaRepository.findByEmail(email)
                 .orElseThrow(MemberNotFoundException::new);
-        if (authenticationRedisRepository.findById(email)
+        if (!authenticationRedisRepository.findById(email)
                 .orElseThrow(EmailNotVerifiedException::new).isVerified()) {
             throw new EmailNotVerifiedException();
         }


### PR DESCRIPTION
이메일 인증 여부를 판단하는 if문의 조건절이 반전처리가 되어 있지 않아 이메일 인증 상태가 ``true``일 때 이메일 인증 실패 예외를 발행하였던 것을 수정하였습니다