### PR TITLE
feat: 동아리 목록 반환 메서드에 캐싱적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     /* JJWT */
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
 
+    /* Cache */
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     /* JJWT */
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/team/themoment/imi/domain/club/service/ClubService.java
+++ b/src/main/java/team/themoment/imi/domain/club/service/ClubService.java
@@ -1,6 +1,7 @@
 package team.themoment.imi.domain.club.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import team.themoment.imi.domain.club.data.response.ClubListResDto;
 import team.themoment.imi.domain.club.entity.Club;
@@ -14,6 +15,7 @@ public class ClubService {
 
     private final ClubJpaRepository clubJpaRepository;
 
+    @Cacheable(key = "'clubs'", value = "clubs")
     public ClubListResDto getAllClubs() {
         List<Club> clubs = clubJpaRepository.findAll();
         return new ClubListResDto(clubs.size(), clubs);

--- a/src/main/java/team/themoment/imi/global/config/CacheConfig.java
+++ b/src/main/java/team/themoment/imi/global/config/CacheConfig.java
@@ -1,0 +1,21 @@
+package team.themoment.imi.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
+        cacheManager.setAllowNullValues(false);
+        cacheManager.setCacheNames(Collections.singleton("clubs"));
+        
+        return cacheManager;
+    }
+}

--- a/src/main/java/team/themoment/imi/global/config/CacheConfig.java
+++ b/src/main/java/team/themoment/imi/global/config/CacheConfig.java
@@ -1,11 +1,13 @@
 package team.themoment.imi.global.config;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
 import java.util.Collections;
 
 @Configuration
@@ -13,11 +15,13 @@ import java.util.Collections;
 public class CacheConfig {
 
     @Bean
-    public CacheManager cacheManager() {
-        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
-        cacheManager.setAllowNullValues(false);
+    public CacheManager caffeineCacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofHours(24))
+                .maximumSize(100)
+        );
         cacheManager.setCacheNames(Collections.singleton("clubs"));
-        
         return cacheManager;
     }
 }

--- a/src/main/java/team/themoment/imi/global/config/CacheConfig.java
+++ b/src/main/java/team/themoment/imi/global/config/CacheConfig.java
@@ -1,6 +1,7 @@
 package team.themoment.imi.global.config;
 
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import java.util.Collections;
 
 @Configuration
+@EnableCaching
 public class CacheConfig {
 
     @Bean


### PR DESCRIPTION
Java Caffeine 라이브러리를 활용하여 동아리 목록을 반환할 때 캐싱을 적용하였습니다.캐시 버저닝은 쓰기가 거의 없고 정적인 데이터라 판단되어 캐싱 후 24시간이 지나면 만료되도록 설정하였습니다