### PR TITLE
feat: RDB 제약조건 위반 예외 핸들링

### DIFF
--- a/src/main/java/team/themoment/imi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team/themoment/imi/global/exception/GlobalExceptionHandler.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-import java.rmi.UnexpectedException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -71,7 +70,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ErrorResponse> handleUnexpectedException(UnexpectedException ex) {
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
         log.error("UnexpectedException Occur : ", ex);
         return ResponseEntity.status(HttpStatus.CONFLICT.value())
                 .body(new ErrorResponse("Data integrity violation has occurred")


### PR DESCRIPTION
``DataIntegrityViolationException`` 예외를 핸들링하여 클라이언트에 409를 반환하도록 하였습니다