### PR TITLE
fix: JWT 클레임에 올바르지 않은 만료시간 값 삽입 문제 해결

### DIFF
--- a/src/main/java/team/themoment/imi/global/security/jwt/service/JwtService.java
+++ b/src/main/java/team/themoment/imi/global/security/jwt/service/JwtService.java
@@ -33,11 +33,14 @@ public class JwtService {
     }
 
     public TokenDto issueAccessToken(String userId) {
-        Date expirationDate = new Date(System.currentTimeMillis() + accessTokenExpiration);
+        long currentTimeMillis = System.currentTimeMillis();
+        long currentTimeSeconds = currentTimeMillis / 1000;
+        Date expirationDate = new Date(currentTimeMillis + (accessTokenExpiration * 1000L));
+        long expirationSeconds = expirationDate.getTime() / 1000;
         String token = Jwts.builder()
                 .claim("sub", userId)
-                .claim("iat", System.currentTimeMillis() / 1000)
-                .claim("exp", expirationDate.getTime() / 1000)
+                .claim("iat", currentTimeSeconds)
+                .claim("exp", expirationSeconds)
                 .claim("jti", UUID.randomUUID().toString())
                 .signWith(key)
                 .compact();
@@ -45,11 +48,14 @@ public class JwtService {
     }
 
     public String issueRefreshToken(String userId) {
-        Date expirationDate = new Date(System.currentTimeMillis() + refreshTokenExpiration);
+        long currentTimeMillis = System.currentTimeMillis();
+        long currentTimeSeconds = currentTimeMillis / 1000;
+        Date expirationDate = new Date(currentTimeMillis + (refreshTokenExpiration * 1000L));
+        long expirationSeconds = expirationDate.getTime() / 1000;
         String token = Jwts.builder()
                 .claim("sub", userId)
-                .claim("iat", System.currentTimeMillis() / 1000)
-                .claim("exp", expirationDate.getTime() / 1000)
+                .claim("iat", currentTimeSeconds)
+                .claim("exp", expirationSeconds)
                 .claim("jti", UUID.randomUUID().toString())
                 .signWith(key)
                 .compact();


### PR DESCRIPTION
밀리초 단위와 초 단위 계산시 혼용으로 인하여 부정확한 값을 삽입하던 문제를 수정하였습니다