### PR TITLE
update: 전공입력 최대 길이 설정

### DIFF
--- a/src/main/java/team/themoment/imi/domain/profile/data/request/UpdateProfileReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/profile/data/request/UpdateProfileReqDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record UpdateProfileReqDto(
-        @NotNull String major,
+        @NotNull @Size(max = 100) String major,
         @NotNull @Size(max = 2400) String content,
         @NotEmpty List<String> wanted
 ) {


### PR DESCRIPTION
기존에 전공을 길게 입력할시, db의 varchar 길이를 초과하여 에러가 발생하던 부분을, 전공 입력에 최대 길이를 명시적으로 설정하여 해결했습니다.