### PR TITLE
update: 학번에 대한 더 엄격한 유효성 검사

### DIFF
--- a/src/main/java/team/themoment/imi/domain/user/data/request/CreateUserReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/user/data/request/CreateUserReqDto.java
@@ -1,6 +1,7 @@
 package team.themoment.imi.domain.user.data.request;
 
 import jakarta.validation.constraints.*;
+import team.themoment.imi.global.utils.ValidStudentId;
 
 public record CreateUserReqDto(
         @NotBlank(message = "이름을 입력해주세요.")
@@ -10,8 +11,7 @@ public record CreateUserReqDto(
                 , message = "이메일 형식이 올바르지 않습니다.")
         String email,
         @NotNull(message = "학번을 입력해주세요.")
-        @Min(value = 1101, message = "학번을 다시 확인해주세요.")
-        @Max(value = 3418, message = "학번을 다시 확인해주세요.")
+        @ValidStudentId(message = "유효하지 않은 학번입니다.")
         Integer studentId,
         @NotBlank(message = "비밀번호를 입력해주세요.")
         String password

--- a/src/main/java/team/themoment/imi/global/utils/StudentIdValidator.java
+++ b/src/main/java/team/themoment/imi/global/utils/StudentIdValidator.java
@@ -1,0 +1,20 @@
+package team.themoment.imi.global.utils;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class StudentIdValidator implements ConstraintValidator<ValidStudentId, Integer> {
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        if (value == null) return true; // @NotNull과 병행 사용해야 함
+
+        if (value < 1000 || value > 3420) return false;
+
+        int clazz = (value / 100) % 10;
+        int number = value % 100;
+
+        return (clazz >= 1 && clazz <= 4) &&
+                (number >= 1 && number <= 20);
+    }
+}

--- a/src/main/java/team/themoment/imi/global/utils/ValidStudentId.java
+++ b/src/main/java/team/themoment/imi/global/utils/ValidStudentId.java
@@ -1,0 +1,20 @@
+package team.themoment.imi.global.utils;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = StudentIdValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidStudentId {
+    String message();
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
# 본문
학번에 대한 더 엄격한 유효성 검사를 추가했습니다.

## 피드백
정원외 특별전형이 학과당 최대 2명 배정될 수 있어, 번호를 20번까지 받도록 해두었으나,
상황이 제한적이고 쓰이지 않을것이라 판단되면 18번까지 받도록 수정하겠습니다.