### PR TITLE
update: 현재 인증된 사용자 정보조회 유틸 클래스 리팩터링

### DIFF
--- a/src/main/java/team/themoment/imi/global/utils/UserUtil.java
+++ b/src/main/java/team/themoment/imi/global/utils/UserUtil.java
@@ -1,25 +1,27 @@
 package team.themoment.imi.global.utils;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import team.themoment.imi.domain.user.entity.User;
+import team.themoment.imi.domain.user.exception.MemberNotFoundException;
 import team.themoment.imi.domain.user.repository.UserJpaRepository;
-import team.themoment.imi.global.exception.GlobalException;
+import team.themoment.imi.global.utils.exception.UnauthenticatedException;
 
 @Component
 @RequiredArgsConstructor
 public class UserUtil {
+
     private final UserJpaRepository userJpaRepository;
-    public User getCurrentUser(){
+
+    public User getCurrentUser() {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if(principal instanceof UserDetails userDetails){
+        if (principal instanceof UserDetails userDetails) {
             return userJpaRepository.findByEmail(userDetails.getUsername())
-                    .orElseThrow(() -> new GlobalException("Login User not found", HttpStatus.NOT_FOUND));
-        }else {
-            throw new GlobalException("User is not authenticated", HttpStatus.UNAUTHORIZED);
+                    .orElseThrow(MemberNotFoundException::new);
+        } else {
+            throw new UnauthenticatedException();
         }
     }
 }

--- a/src/main/java/team/themoment/imi/global/utils/exception/UnauthenticatedException.java
+++ b/src/main/java/team/themoment/imi/global/utils/exception/UnauthenticatedException.java
@@ -1,0 +1,10 @@
+package team.themoment.imi.global.utils.exception;
+
+import org.springframework.http.HttpStatus;
+import team.themoment.imi.global.exception.GlobalException;
+
+public class UnauthenticatedException extends GlobalException {
+    public UnauthenticatedException() {
+        super("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
기존 ``UserUtil`` 클래스에서 애플리케이션 전체적으로 범용 ``GlobalException``을 재정의하여 구체적인 예외 클래스로 예외를 던지던 규칙을 벗어나 범용 예외를 직접 던지던 것을 리팩터링하였습니다.