### PR TITLE
update: 희망전공 파라미터 최대 길이 조정

### DIFF
--- a/src/main/java/team/themoment/imi/domain/profile/data/request/UpdateProfileReqDto.java
+++ b/src/main/java/team/themoment/imi/domain/profile/data/request/UpdateProfileReqDto.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public record UpdateProfileReqDto(
         @NotNull(message = "희망전공은 필수입니다.")
-        @Size(max = 100)
+        @Size(max = 50, message = "희망전공은 최대 50자까지 입력할 수 있습니다.")
         String major,
         @NotNull(message = "자기소개는 필수입니다.")
         @Size(max = 2400, message = "자기소개는 최대 2400자까지 입력할 수 있습니다.")


### PR DESCRIPTION
웹 클라이언트 단에서 희망전공 필드의 값 길이를 50자로 제한둠에 다라 서버에서도 동일한 조건을 적용하도록 하였습니다.
- https://github.com/themoment-team/imi-frontend/pull/62